### PR TITLE
Fixed 'en' translations and added 'it' translations

### DIFF
--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -6,6 +6,6 @@ return [
     'money_positive_or_zero' => 'The value is not a valid positive or zero money',
     'money_negative' => 'The value is not a valid negative money',
     'money_negative_or_zero' => 'The value is not a valid negative or zero money',
-    'money_min' => 'The value must be less than :value',
-    'money_max' => 'The value must be greater than :value',
+    'money_min' => 'The value must be greater than :value',
+    'money_max' => 'The value must be less than :value',
 ];

--- a/resources/lang/it/validation.php
+++ b/resources/lang/it/validation.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'money' => 'Il valore non è un importo valido',
+    'money_positive' => 'Questo valore non è un importo maggiore di 0',
+    'money_positive_or_zero' => 'Questo valore non è un importo maggiore o uguale a 0',
+    'money_negative' => 'Questo valore non è un importo minore di 0',
+    'money_negative_or_zero' => 'Questo valore non è un importo minore o uguale a 0',
+    'money_min' => 'Il valore deve essere maggiore di :value',
+    'money_max' => 'Il valore deve essere minore di :value',
+];


### PR DESCRIPTION
The `en` translation was wrong.

If you use `ValidMoney(min: 10, max: 100)` which I assume means `10 < value < 100` and pass `1` as the value, the english error was `The value must be less than 10` which makes no sense because `1` is less than `10` 😅

The french translation is indeed correct: `Cette valeur doit être supérieur à 10`.

I took this opportunity to add the Italian translation.