### PR TITLE
Allow decimal amounts as min and max value for ValidMoney

### DIFF
--- a/src/Rules/ValidMoney.php
+++ b/src/Rules/ValidMoney.php
@@ -7,13 +7,15 @@ namespace Elegantly\Money\Rules;
 use Closure;
 use Elegantly\Money\MoneyParser;
 use Illuminate\Contracts\Validation\ValidationRule;
+use Brick\Money\AbstractMoney;
+use Brick\Math\BigNumber;
 
 class ValidMoney implements ValidationRule
 {
     public function __construct(
         public bool $nullable = true,
-        public ?int $min = null,
-        public ?int $max = null
+        public AbstractMoney|BigNumber|int|float|string|null $min = null,
+        public AbstractMoney|BigNumber|int|float|string|null $max = null
     ) {
         //
     }

--- a/tests/ValidMoneyTest.php
+++ b/tests/ValidMoneyTest.php
@@ -6,7 +6,7 @@ use Elegantly\Money\Rules\ValidMoney;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
 
-it('validate money', function ($amount, bool $expected, ?int $min = null, ?int $max = null, bool $nullable = true) {
+it('validate money', function ($amount, bool $expected, mixed $min = null, mixed $max = null, bool $nullable = true) {
 
     $rule = new ValidMoney(min: $min, max: $max, nullable: $nullable);
 
@@ -40,4 +40,6 @@ it('validate money', function ($amount, bool $expected, ?int $min = null, ?int $
     ['EUR 20', true, 10, 20],
     ['EUR 1', false, 10, 20],
     ['EUR 100', false, 10, 20],
+    ['EUR 0.50', true, 0.50, 20],
+    ['EUR 0.40', false, 0.50, 20],
 ]);


### PR DESCRIPTION
Make the ValidMoney rule min and max parameters accept the same types as Brick Moneys' isLessThan() and isGreaterThan() methods that it feeds them into.

This should not break any existing implementations, but allow for min and max amounts that are not whole numbers. Since the minimum transaction amount on Stripe for euro's is €0.50 for example...

Bonne nuit !